### PR TITLE
Store CLA signatures outside protected main

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           path-to-signatures: '.github/cla-signatures.json'
           path-to-document: 'https://github.com/Makson179/Bello/blob/main/CLA.md'
-          branch: 'main'
+          branch: 'cla-signatures'
           allowlist: 'Makson179,AlexeyKulaev,dependabot[bot]'


### PR DESCRIPTION
Move the CLA Assistant signature store to the dedicated `cla-signatures` branch so `main` can be protected without blocking signature updates.\n\nThe signature branch was created from the current `main`, preserving the existing `.github/cla-signatures.json` file. No application code changes.