### PR TITLE
Fix mode terms and recovery default

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ an **adversarial pass**. Runtime supervision remains active in every mode.
 
 | Mode | Best for | What you get |
 | --- | --- | --- |
-| `runtime-only` | Everyday autonomous work | Spots when the coder takes a wrong turn and steers the run back toward the task. |
+| `runtime-only` | Routine autonomous work | Spots when the coder takes a wrong turn and steers the run back toward the task. |
 | `C+A` | High-quality work on a practical budget | Captures 69% of the full schedule's gain while keeping every runtime safeguard. |
 | `4C+A+2C` | Flagship, high-stakes work | The deepest review schedule, delivering about 40% higher benchmark completion than Raw Codex. |
 
@@ -377,7 +377,7 @@ bello config
 It creates and edits `.supervisor/config.json`. Every value is saved as you
 press Enter; future runs in this folder use these settings automatically.
 
-The editor starts in Everyday mode for a new project and only shows settings
+The editor starts in `runtime-only` mode for a new project and only shows settings
 that can affect the selected pipeline. Turning on `completion-review` reveals
 the completion reviewer and review budget. Turning on `adversary` then reveals
 the adversary model and the complete `C+A` schedule.
@@ -400,19 +400,19 @@ runtime and review budgets, are changed through `bello config`.
 | `runtime-mod` | GPT-5.6 | Model family for fresh-context runtime checks, including risky-action judgment and drift detection. |
 | `runtime-5.6-variant` | Sol | GPT-5.6 variant for the full runtime supervisor. |
 | `runtime-intelligence` | `xhigh` | Full runtime supervisor reasoning effort. |
-| `completion-mod` | GPT-5.6 | Model family for the independent read-only completion reviewer. Hidden in Everyday mode. |
-| `completion-5.6-variant` | Sol | GPT-5.6 variant for completion review. Hidden in Everyday mode. |
-| `completion-intelligence` | `xhigh` | Completion reviewer reasoning effort. Hidden in Everyday mode. |
+| `completion-mod` | GPT-5.6 | Model family for the independent read-only completion reviewer. Hidden in `runtime-only` mode. |
+| `completion-5.6-variant` | Sol | GPT-5.6 variant for completion review. Hidden in `runtime-only` mode. |
+| `completion-intelligence` | `xhigh` | Completion reviewer reasoning effort. Hidden in `runtime-only` mode. |
 | `adversary-mod` | GPT-5.6 | Adversarial tester model family. Visible only when the adversary is enabled. |
 | `adversary-5.6-variant` | Sol | GPT-5.6 variant for the adversary. Visible only when the adversary is enabled. |
 | `adversary-intelligence` | `xhigh` | Adversary reasoning effort. Visible only when the adversary is enabled. |
 | `speed` | `usual` | `fast` uses the Codex Fast service tier for coder, runtime-supervisor, and completion-review turns. Adversary turns are unchanged. |
 | `cheap-runtime` | `true` | Let Luna dismiss routine runtime checks before invoking the full runtime supervisor. Human messages, approvals, and mandatory checks bypass triage. |
-| `start-over` | `true` | `true` removes prior Bello logs, archived runs, and recovery data; `false` preserves them. Both start fresh active state and leave project files unchanged. |
-| `completion-review` | `false` | `false` is Everyday. `true` enables the independent completion-review loop and reveals its settings. |
+| `start-over` | `false` | `true` removes prior Bello logs, archived runs, and recovery data; `false` preserves them. Both start fresh active state and leave project files unchanged. |
+| `completion-review` | `false` | `false` selects `runtime-only`. `true` enables the independent completion-review loop and reveals its settings. |
 | `adversary` | `false` | Enable the adversarial tester before completion. Requires completion review. |
 | `max-reviews` / `max-reviews-before-adversary` | `1` | Completion-return budget. Without an adversary it is shown as `max-reviews`; with an adversary it limits returns before the first pass. An earlier accept starts the adversary immediately. `0` skips these rounds; `Unlimited` removes the cap. |
-| `max-adversary-runs` | `1` | Maximum adversary passes in Deep Work. `0` disables the adversary. |
+| `max-adversary-runs` | `1` | Maximum adversary passes when the adversary is enabled. `0` disables the adversary. |
 | `max-reviews-after-adversary` | `0` | Maximum additional completion-review rounds after each adversary pass. At the limit Bello starts the next pass or completes after the final one. `0` schedules none; `Unlimited` removes the cap. A candidate adversary finding is still adjudicated once. |
 | `clean` | `false` | **Warning:** deletes **everything** in the folder except the task file and configured protected paths before starting. Only for disposable folders where you want a from-scratch build. |
 | `protected-path` | absent | Paths the coder must never write to, such as golden tests, fixtures, or production configs. They are also preserved by `clean`. |
@@ -444,7 +444,7 @@ Run flags (each overrides the saved config for one run):
 | `--adversary-intelligence V` | Adversarial tester reasoning effort. |
 | <code>--fast[=true&#124;false]</code> | Codex Fast service tier. |
 | <code>--start-over[=true&#124;false]</code> | Fresh `.supervisor/` state. |
-| <code>--completion-review[=true&#124;false]</code> | Completion-review loop on/off (`false` = Everyday and disables the adversary). |
+| <code>--completion-review[=true&#124;false]</code> | Completion-review loop on/off (`false` selects `runtime-only` and disables the adversary). |
 | <code>--adversary[=true&#124;false]</code> | Adversarial tester on/off. |
 | `--adversary-runs N` | Adversary pass budget; `0` disables. |
 | <code>--clean[=true&#124;false]</code> | **Warning:** wipe the folder except the task file and protected paths before starting. |

--- a/supervisor/project_config.py
+++ b/supervisor/project_config.py
@@ -69,7 +69,7 @@ class ProjectConfig:
     adversary_intelligence: str = DEFAULT_INTELLIGENCE
     speed: str = "usual"
     cheap_runtime: bool = True
-    start_over: bool = True
+    start_over: bool = False
     completion_review: bool = False
     adversary: bool = False
     adversary_runs: int = 1

--- a/tests/test_cli_model_flags.py
+++ b/tests/test_cli_model_flags.py
@@ -427,6 +427,7 @@ def test_fresh_project_uses_everyday_defaults() -> None:
     assert settings.runtime_model == MODEL_GPT_5_6_SOL
     assert settings.coder_intelligence == "xhigh"
     assert settings.runtime_intelligence == "xhigh"
+    assert settings.start_over is False
     assert settings.completion_review is False
     assert settings.adversary is False
 

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -407,7 +407,7 @@ def test_cli_fast_flag_reaches_runner(monkeypatch: pytest.MonkeyPatch, tmp_path)
             DEFAULT_INTELLIGENCE,
             DEFAULT_INTELLIGENCE,
             True,
-            True,
+            False,
             (),
             False,
             False,

--- a/tests/test_config_editor_render.py
+++ b/tests/test_config_editor_render.py
@@ -208,6 +208,7 @@ def test_config_editor_default_surface_is_everyday() -> None:
     keys = {param.key for param in params}
 
     assert next(param for param in params if param.key == "completion_review").value == "false"
+    assert next(param for param in params if param.key == "start_over").value == "false"
     assert {"coder_mod", "runtime_mod", "cheap_runtime", "completion_review"}.issubset(keys)
     assert {
         "completion_mod",

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -47,7 +47,7 @@ def test_first_load_creates_default_project_config(tmp_path: Path) -> None:
     assert config.runtime_intelligence == DEFAULT_INTELLIGENCE
     assert config.completion_intelligence == DEFAULT_INTELLIGENCE
     assert config.adversary_intelligence == DEFAULT_INTELLIGENCE
-    assert config.start_over is True
+    assert config.start_over is False
     assert config.completion_review is False
     assert config.adversary is False
     assert config.adversary_runs == 1
@@ -86,7 +86,7 @@ def test_project_config_missing_fields_are_defaulted(tmp_path: Path) -> None:
     assert config.runtime_mod == DEFAULT_MODEL
     assert config.completion_mod == DEFAULT_MODEL
     assert config.adversary_mod == DEFAULT_MODEL
-    assert config.start_over is True
+    assert config.start_over is False
     assert config.completion_returns_before_adversary == 4
     assert config.completion_returns_after_adversary == 2
 


### PR DESCRIPTION
## Summary
- replace legacy Everyday and Deep Work terminology in the README
- default start-over to false so recovery data is preserved
- update configuration, CLI, and editor coverage

## Validation
- .venv/bin/python -m pytest tests/test_project_config.py tests/test_cli_model_flags.py tests/test_config_editor_render.py tests/test_cli_update.py (143 passed)
- git diff --check