### PR TITLE
Release Bello 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Bello"
-version = "0.4.0"
+version = "0.4.1"
 description = "Terminal supervisor for autonomous Codex app-server runs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/supervisor/appserver.py
+++ b/supervisor/appserver.py
@@ -188,7 +188,7 @@ class AppServerClient:
         result = await self.request(
             "initialize",
             {
-                "clientInfo": {"name": "bello", "title": "Bello", "version": "0.4.0"},
+                "clientInfo": {"name": "bello", "title": "Bello", "version": "0.4.1"},
                 "capabilities": {"experimentalApi": True, "requestAttestation": False},
             },
             timeout=timeout,

--- a/supervisor/controller.py
+++ b/supervisor/controller.py
@@ -1559,7 +1559,7 @@ class BelloController:
         result: str,
         *,
         status: BelloStatus = BelloStatus.COMPLETE,
-        completion_review_accepted: bool = False,
+        completion_review_accepted: bool | None = False,
     ) -> None:
         self._reconcile_intervention_accounting()
         diff = await self.diff_summary()
@@ -3372,9 +3372,9 @@ class BelloController:
         )
         self._accepted_completion_decision = None
         await self.finalize(
-            f"completed by bounded review policy: {reason}",
+            "completed normally",
             status=BelloStatus.COMPLETE,
-            completion_review_accepted=False,
+            completion_review_accepted=None,
         )
 
     async def _fail_required_adversary(

--- a/supervisor/schemas/models.py
+++ b/supervisor/schemas/models.py
@@ -890,7 +890,7 @@ class FinalReport(BaseModel):
     denied_actions: list[str] = Field(default_factory=list)
     interventions: int = 0
     restarts: int = 0
-    completion_review_accepted: bool = False
+    completion_review_accepted: bool | None = False
     completion_returns: int = 0
     completion_restarts: int = 0
     no_marker_idle_nudges: int = 0

--- a/supervisor/state.py
+++ b/supervisor/state.py
@@ -316,11 +316,18 @@ class StateStore:
                 f"- Result: {report.result}",
                 f"- Restarts: {report.restarts}",
                 f"- Interventions: {report.interventions}",
-                f"- Completion review accepted: {str(report.completion_review_accepted).lower()}",
-                f"- Completion returns: {report.completion_returns}",
-                f"- Completion restarts: {report.completion_restarts}",
-                f"- No-marker idle nudges: {report.no_marker_idle_nudges}",
             ]
+            if report.completion_review_accepted is not None:
+                lines.append(
+                    f"- Completion review accepted: {str(report.completion_review_accepted).lower()}"
+                )
+            lines.extend(
+                [
+                    f"- Completion returns: {report.completion_returns}",
+                    f"- Completion restarts: {report.completion_restarts}",
+                    f"- No-marker idle nudges: {report.no_marker_idle_nudges}",
+                ]
+            )
             if report.files_changed:
                 lines.extend(["", "## Files Changed", *[f"- {path}" for path in report.files_changed]])
             if report.validations:

--- a/tests/test_bello_state.py
+++ b/tests/test_bello_state.py
@@ -542,6 +542,27 @@ def test_final_report_rendering(tmp_path: Path) -> None:
     assert "- a.py" in text
 
 
+def test_final_report_omits_completion_review_status_when_not_applicable(tmp_path: Path) -> None:
+    task = tmp_path / "TASK.md"
+    task.write_text("# Task", encoding="utf-8")
+    store = StateStore(tmp_path)
+    store.initialize_bello(BelloConfig(project_root=str(tmp_path), task_path=str(task)), overwrite=True)
+
+    store.write_final_report(
+        FinalReport(
+            task_path=str(task),
+            status="complete",
+            result="completed normally",
+            completion_review_accepted=None,
+        )
+    )
+
+    text = store.path(FINAL_REPORT).read_text(encoding="utf-8")
+    assert "- Status: complete" in text
+    assert "- Result: completed normally" in text
+    assert "Completion review accepted" not in text
+
+
 async def test_final_report_non_git_omits_git_usage_and_includes_validations(tmp_path: Path) -> None:
     task = tmp_path / "TASK.md"
     task.write_text("# Task", encoding="utf-8")
@@ -1215,7 +1236,9 @@ async def test_exact_marker_triggers_completion_review_accept(tmp_path: Path) ->
     assert len(fake.completion_packets) == 1
     assert fake.completion_packets[0].last_coder_message.text.endswith("BELLO_READY_FOR_REVIEW")
     assert store.get_bello_config().status == BelloStatus.COMPLETE
-    assert "accepted by completion_review" in store.path(FINAL_REPORT).read_text(encoding="utf-8")
+    report = store.path(FINAL_REPORT).read_text(encoding="utf-8")
+    assert "accepted by completion_review" in report
+    assert "- Completion review accepted: true" in report
 
 
 async def test_summary_done_without_marker_steers_for_exact_marker_not_completion(tmp_path: Path) -> None:
@@ -4915,13 +4938,13 @@ async def test_completion_only_review_budget_finalizes_without_restart_or_extra_
             }
         )
     )
-    finalized: list[tuple[str, BelloStatus, bool]] = []
+    finalized: list[tuple[str, BelloStatus, bool | None]] = []
 
     async def capture_finalize(
         result: str,
         *,
         status: BelloStatus = BelloStatus.COMPLETE,
-        completion_review_accepted: bool = False,
+        completion_review_accepted: bool | None = False,
     ) -> None:
         finalized.append((result, status, completion_review_accepted))
 
@@ -4933,9 +4956,9 @@ async def test_completion_only_review_budget_finalizes_without_restart_or_extra_
     assert controller.completion_restarts == 0
     assert finalized == [
         (
-            "completed by bounded review policy: completion review budget exhausted",
+            "completed normally",
             BelloStatus.COMPLETE,
-            False,
+            None,
         )
     ]
 
@@ -5049,13 +5072,13 @@ async def test_pre_adversary_return_budget_runs_adversary_without_an_extra_compl
             }
         )
     )
-    finalized: list[tuple[str, BelloStatus, bool]] = []
+    finalized: list[tuple[str, BelloStatus, bool | None]] = []
 
     async def capture_finalize(
         result: str,
         *,
         status: BelloStatus = BelloStatus.COMPLETE,
-        completion_review_accepted: bool = False,
+        completion_review_accepted: bool | None = False,
     ) -> None:
         finalized.append((result, status, completion_review_accepted))
 
@@ -5083,9 +5106,9 @@ async def test_pre_adversary_return_budget_runs_adversary_without_an_extra_compl
     assert cfg.completion_returns_since_adversary == 0
     assert finalized == [
         (
-            "completed by bounded review policy: completion review budget reached and the normalized adversary report had nothing for the coder",
+            "completed normally",
             BelloStatus.COMPLETE,
-            False,
+            None,
         )
     ]
 
@@ -5107,13 +5130,13 @@ async def test_post_adversary_return_budget_finalizes_on_next_readiness_without_
             }
         )
     )
-    finalized: list[tuple[str, BelloStatus, bool]] = []
+    finalized: list[tuple[str, BelloStatus, bool | None]] = []
 
     async def capture_finalize(
         result: str,
         *,
         status: BelloStatus = BelloStatus.COMPLETE,
-        completion_review_accepted: bool = False,
+        completion_review_accepted: bool | None = False,
     ) -> None:
         finalized.append((result, status, completion_review_accepted))
 
@@ -5124,14 +5147,15 @@ async def test_post_adversary_return_budget_finalizes_on_next_readiness_without_
     assert fake.completion_packets == []
     assert finalized == [
         (
-            "completed by bounded review policy: post-adversary completion review budget exhausted",
+            "completed normally",
             BelloStatus.COMPLETE,
-            False,
+            None,
         )
     ]
     events = [json.loads(line) for line in store.path(EVENTS).read_text(encoding="utf-8").splitlines()]
     assert events[-1]["event_type"] == "completion/budget_finalize"
     assert events[-1]["decision"]["completion_return_count"] == 9
+    assert events[-1]["reason"] == "post-adversary completion review budget exhausted"
 
 
 async def test_required_budget_adversary_failure_is_not_reported_as_success(


### PR DESCRIPTION
## Summary

- report configured bounded-review completion as `completed normally`
- omit the misleading completion-review acceptance line only for that normal bounded path
- preserve detailed budget-finalization reasons in structured internal events
- bump the package and app-server client version to 0.4.1

## Validation

- 602 tests passed locally on Python 3.14
- changed files pass Ruff
- wheel and sdist built successfully
- `twine check` passed for both artifacts
- clean wheel installation reports Bello 0.4.1
- packaged `prompts.toml` and dependency integrity verified