### PR TITLE
docs: polish repository links and wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <p align="center">
   <strong>An autonomous coding loop with independent verification.</strong><br>
-  You write the task in a file and leave. Bello keeps the coder inside a disposable sandbox while a separate supervisor, running on a fresh context, reviews risky actions, catches drift, and handles recovery. On ProgramBench, averaged over nine matched runs with GPT-5.5 and GPT-5.6 Sol, the highest-effort setup raised completion by 36.4% relative to Raw Codex. <br>
+  You write the task in a file and leave. Bello keeps the coder inside a disposable sandbox while a separate supervisor, running on a fresh context, reviews risky actions, catches drift, and handles recovery. On ProgramBench, averaged over nine matched runs with GPT-5.5 and GPT-5.6 Sol, the highest-effort setup raised completion by 36.4% relative to Raw Codex.<br>
 </p>
 
 <p align="center">
-  <a href="https://github.com/Makson179/Bello/actions/workflows/tests.yml"><img alt="Tests" src="https://github.com/Makson179/Bello/actions/workflows/tests.yml/badge.svg"></a>
+  <a href="https://github.com/hardtofindg/Bello/actions/workflows/tests.yml"><img alt="Tests" src="https://github.com/hardtofindg/Bello/actions/workflows/tests.yml/badge.svg"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-0F766E?style=flat-square"></a>
   <img alt="Transport: Codex app-server JSON-RPC" src="https://img.shields.io/badge/transport-codex%20app--server-334155?style=flat-square">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/hardtofindg/Bello/actions/workflows/tests.yml"><img alt="Tests" src="https://github.com/hardtofindg/Bello/actions/workflows/tests.yml/badge.svg"></a>
+  <a href="https://github.com/Makson179/Bello/actions/workflows/tests.yml"><img alt="Tests" src="https://github.com/Makson179/Bello/actions/workflows/tests.yml/badge.svg"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11%2B-3776AB?style=flat-square&logo=python&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-0F766E?style=flat-square"></a>
   <img alt="Transport: Codex app-server JSON-RPC" src="https://img.shields.io/badge/transport-codex%20app--server-334155?style=flat-square">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,13 +6,13 @@ Please report suspected security issues privately by email:
 
 **sentinelsupervisor.security@gmail.com**
 
-We aim to respond within 5 days.
+We aim to respond within five days.
 
 Good security reports include:
 
 - a short description of the issue;
 - steps to reproduce it;
-- expected vs. actual behavior;
+- expected and actual behavior;
 - relevant logs, commands, configuration, or version information.
 
 Please do not open a public GitHub issue for a suspected vulnerability until it
@@ -21,4 +21,4 @@ has been reviewed.
 ## Other Bugs
 
 For non-security bugs, feature requests, documentation issues, and general
-questions, use GitHub Issues.
+questions, use [GitHub Issues](https://github.com/hardtofindg/Bello/issues).


### PR DESCRIPTION
## Summary

- normalize the README intro line break markup
- make small wording improvements in the security policy
- link non-security reports directly to GitHub Issues

## Validation

- `git diff --check`
- documentation-only changes; runtime behavior is unchanged