### PR TITLE
docs: add README video overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 ## Contents
 
 - [TL;DR](#tldr)
+- [Demo](#demo)
 - [Motivation](#motivation)
 - [How Bello solves tasks](#how-bello-solves-tasks)
 - [Relationship to existing LLM research](#relationship-to-existing-llm-research)
@@ -64,6 +65,14 @@ status, the changed files, the checks that ran, and the risks that are left.
 
 The cheapest setting costs about what Codex costs on its own, and the deepest
 scored 36.4% higher than Codex on the [benchmark runs](#results).
+
+---
+
+## Demo
+
+A complete Bello run in 57 seconds:
+
+https://github.com/user-attachments/assets/2e4feb56-35ed-49de-a700-b973af979187
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Contents
 
 - [TL;DR](#tldr)
-- [Demo](#demo)
+- [Bello in 57 seconds](#bello-in-57-seconds)
 - [Motivation](#motivation)
 - [How Bello solves tasks](#how-bello-solves-tasks)
 - [Relationship to existing LLM research](#relationship-to-existing-llm-research)
@@ -68,9 +68,7 @@ scored 36.4% higher than Codex on the [benchmark runs](#results).
 
 ---
 
-## Demo
-
-A complete Bello run in 57 seconds:
+## Bello in 57 seconds
 
 https://github.com/user-attachments/assets/2e4feb56-35ed-49de-a700-b973af979187
 


### PR DESCRIPTION
## Summary

- replace the README hero GIF with the optimized version
- add a `Bello in 57 seconds` video section after TL;DR
- link the new section from Contents