### PR TITLE
Fix Windows Codex home isolation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,4 +66,67 @@ jobs:
           New-Item -ItemType Directory -Force -Path $fixtureBin | Out-Null
           Copy-Item "tests/windows_fixtures/*" $fixtureBin
           $env:PATH = "$fixtureBin;$env:PATH"
-          bello doctor
+
+          # Reproduce the normal native-Windows CODEX_HOME shape that caused
+          # issue #22: installer/plugin junctions plus files held with
+          # FILE_SHARE_NONE by a running Codex process.
+          $codexHome = Join-Path $env:RUNNER_TEMP "bello-doctor-codex-home"
+          New-Item -ItemType Directory -Force -Path $codexHome | Out-Null
+          Set-Content -Path (Join-Path $codexHome "auth.json") -Value '{"token":"fixture"}'
+          Set-Content -Path (Join-Path $codexHome "config.toml") -Value 'model = "gpt-test"'
+
+          $packageTarget = Join-Path $codexHome "packages/standalone/1.2.3"
+          $packageJunction = Join-Path $codexHome "packages/standalone/current"
+          New-Item -ItemType Directory -Force -Path (Split-Path $packageJunction) | Out-Null
+          New-Item -ItemType Directory -Force -Path $packageTarget | Out-Null
+          New-Item -ItemType Junction -Path $packageJunction -Target $packageTarget | Out-Null
+
+          $pluginTarget = Join-Path $codexHome "plugins/cache/openai-bundled/chrome/1.2.3"
+          $pluginJunction = Join-Path $codexHome "plugins/cache/openai-bundled/chrome/latest"
+          New-Item -ItemType Directory -Force -Path (Split-Path $pluginJunction) | Out-Null
+          New-Item -ItemType Directory -Force -Path $pluginTarget | Out-Null
+          Set-Content -Path (Join-Path $pluginTarget "SKILL.md") -Value '# fixture plugin'
+          New-Item -ItemType Junction -Path $pluginJunction -Target $pluginTarget | Out-Null
+          $pluginState = Join-Path $codexHome "plugins/data/bello.json"
+          New-Item -ItemType Directory -Force -Path (Split-Path $pluginState) | Out-Null
+          Set-Content -Path $pluginState -Value '{"enabled":true}'
+
+          $writerLock = Join-Path $codexHome "thread-writer-locks/active.lock"
+          $tempLock = Join-Path $codexHome "tmp/arg0/active.lock"
+          $dotTempLock = Join-Path $codexHome ".tmp/plugins.sync.lock"
+          New-Item -ItemType Directory -Force -Path (Split-Path $writerLock) | Out-Null
+          New-Item -ItemType Directory -Force -Path (Split-Path $tempLock) | Out-Null
+          New-Item -ItemType Directory -Force -Path (Split-Path $dotTempLock) | Out-Null
+          $env:CODEX_HOME = $codexHome
+          $writerStream = $null
+          $tempStream = $null
+          $dotTempStream = $null
+          try {
+            $writerStream = [System.IO.File]::Open(
+              $writerLock,
+              [System.IO.FileMode]::OpenOrCreate,
+              [System.IO.FileAccess]::ReadWrite,
+              [System.IO.FileShare]::None
+            )
+            $tempStream = [System.IO.File]::Open(
+              $tempLock,
+              [System.IO.FileMode]::OpenOrCreate,
+              [System.IO.FileAccess]::ReadWrite,
+              [System.IO.FileShare]::None
+            )
+            $dotTempStream = [System.IO.File]::Open(
+              $dotTempLock,
+              [System.IO.FileMode]::OpenOrCreate,
+              [System.IO.FileAccess]::ReadWrite,
+              [System.IO.FileShare]::None
+            )
+            bello doctor
+            if ($LASTEXITCODE -ne 0) {
+              throw "bello doctor failed with exit code $LASTEXITCODE"
+            }
+          }
+          finally {
+            if ($dotTempStream) { $dotTempStream.Dispose() }
+            if ($tempStream) { $tempStream.Dispose() }
+            if ($writerStream) { $writerStream.Dispose() }
+          }

--- a/supervisor/appserver.py
+++ b/supervisor/appserver.py
@@ -104,6 +104,19 @@ _WINDOWS_CREATE_SUSPENDED = getattr(subprocess, "CREATE_SUSPENDED", 0x00000004)
 _WINDOWS_CTRL_BREAK_EVENT = getattr(signal, "CTRL_BREAK_EVENT", 1)
 _WINDOWS_JOB_OBJECT_LIMIT_KILL_ON_CLOSE = 0x00002000
 
+# Codex owns these directories as reconstructible runtime state.  Copying them
+# into the isolated home is both unnecessary and unsafe on native Windows:
+# packages contain installer-managed junctions, while lock/temp directories can
+# contain files opened with exclusive sharing.  Versioned plugin payloads are
+# preserved; only replaceable ``latest`` reparse aliases are omitted.
+# Persistent user state remains subject to the normal fail-closed validation.
+_WINDOWS_CODEX_HOME_SKIPPED_TOP_LEVEL = frozenset(
+    {".tmp", "packages", "thread-writer-locks", "tmp"}
+)
+_WINDOWS_CODEX_HOME_PLUGIN_CACHE_PREFIX = ("plugins", "cache")
+_WINDOWS_CODEX_HOME_PLUGIN_ALIAS = "latest"
+_WINDOWS_CODEX_HOME_PLUGIN_ALIAS_DEPTH = 5
+
 
 def _app_server_process_kwargs() -> dict[str, Any]:
     if _IS_WINDOWS:
@@ -893,9 +906,15 @@ def _create_isolated_codex_home(source: Path) -> Path:
         for child in children:
             if child.name == "rules" or (_IS_WINDOWS and child.name.casefold() == "rules"):
                 continue
+            if _IS_WINDOWS and _is_skipped_windows_codex_home_entry(source, child):
+                continue
             destination = isolated / child.name
             if _IS_WINDOWS:
-                _copy_windows_codex_home_entry(child, destination)
+                _copy_windows_codex_home_entry(
+                    child,
+                    destination,
+                    codex_home_root=source,
+                )
             else:
                 os.symlink(str(child), destination, target_is_directory=child.is_dir())
         (isolated / "rules").mkdir(mode=0o700)
@@ -922,14 +941,58 @@ def _validate_windows_codex_home_names(directory: Path, names: list[str]) -> Non
         seen[key] = name
 
 
-def _copy_windows_codex_home_entry(source: Path, destination: Path) -> None:
-    _validate_windows_codex_home_entry(source)
+def _is_skipped_windows_codex_home_entry(codex_home_root: Path, path: Path) -> bool:
+    try:
+        relative_parts = path.relative_to(codex_home_root).parts
+    except ValueError:
+        return False
+    folded_parts = tuple(part.casefold() for part in relative_parts)
+    if len(folded_parts) == 1:
+        return folded_parts[0] in _WINDOWS_CODEX_HOME_SKIPPED_TOP_LEVEL
+    is_plugin_latest = (
+        len(folded_parts) == _WINDOWS_CODEX_HOME_PLUGIN_ALIAS_DEPTH
+        and folded_parts[:2] == _WINDOWS_CODEX_HOME_PLUGIN_CACHE_PREFIX
+        and folded_parts[-1] == _WINDOWS_CODEX_HOME_PLUGIN_ALIAS
+    )
+    if not is_plugin_latest:
+        return False
+    metadata = path.lstat()
+    return is_link_or_reparse(path, stat_result=metadata)
+
+
+def _copy_windows_codex_home_entry(
+    source: Path,
+    destination: Path,
+    *,
+    codex_home_root: Path | None = None,
+) -> None:
+    _validate_windows_codex_home_entry(source, codex_home_root=codex_home_root)
     metadata = source.lstat()
     metadata = _assert_stable_codex_entry(
         source, metadata, require_directory=stat.S_ISDIR(metadata.st_mode)
     )
     if stat.S_ISDIR(metadata.st_mode):
-        shutil.copytree(source, destination, symlinks=False, copy_function=shutil.copy2)
+
+        def ignore_reconstructible_runtime_state(
+            directory: str,
+            names: list[str],
+        ) -> list[str]:
+            if codex_home_root is None:
+                return []
+            parent = Path(directory)
+            return [
+                name
+                for name in names
+                if _is_skipped_windows_codex_home_entry(codex_home_root, parent / name)
+            ]
+
+        shutil.copytree(
+            source,
+            destination,
+            symlinks=False,
+            copy_function=shutil.copy2,
+            ignore=ignore_reconstructible_runtime_state,
+        )
         _assert_stable_codex_entry(source, metadata, require_directory=True)
         _validate_windows_codex_home_entry(destination)
         _make_codex_home_copy_writable(destination)
@@ -943,7 +1006,11 @@ def _copy_windows_codex_home_entry(source: Path, destination: Path) -> None:
     raise AppServerError(f"unsupported Windows CODEX_HOME entry: {source}")
 
 
-def _validate_windows_codex_home_entry(source: Path) -> None:
+def _validate_windows_codex_home_entry(
+    source: Path,
+    *,
+    codex_home_root: Path | None = None,
+) -> None:
     metadata = source.lstat()
     if is_link_or_reparse(source, stat_result=metadata):
         raise AppServerError(
@@ -961,7 +1028,12 @@ def _validate_windows_codex_home_entry(source: Path) -> None:
     _validate_windows_codex_home_names(source, [child.name for child in children])
     for child in children:
         _assert_stable_codex_entry(source, metadata, require_directory=True)
-        _validate_windows_codex_home_entry(child)
+        if codex_home_root is not None and _is_skipped_windows_codex_home_entry(
+            codex_home_root,
+            child,
+        ):
+            continue
+        _validate_windows_codex_home_entry(child, codex_home_root=codex_home_root)
     _assert_stable_codex_entry(source, metadata, require_directory=True)
 
 

--- a/tests/test_appserver.py
+++ b/tests/test_appserver.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -175,6 +177,131 @@ def test_isolated_codex_home_windows_copy_is_independent_and_needs_no_symlinks(
     assert not isolated.exists()
 
 
+def test_isolated_codex_home_windows_skips_reconstructible_runtime_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "codex-home"
+    source.mkdir()
+    (source / "auth.json").write_text('{"token": "source"}\n', encoding="utf-8")
+
+    package_junction = source / "Packages" / "standalone" / "current"
+    package_junction.mkdir(parents=True)
+    plugin_cache_junction = (
+        source / "Plugins" / "CACHE" / "market" / "bundle" / "latest"
+    )
+    plugin_cache_junction.mkdir(parents=True)
+    plugin_payload = (
+        source
+        / "Plugins"
+        / "CACHE"
+        / "market"
+        / "bundle"
+        / "1.2.3"
+        / "SKILL.md"
+    )
+    plugin_payload.parent.mkdir(parents=True)
+    plugin_payload.write_text("plugin skill\n", encoding="utf-8")
+    nested_latest = plugin_payload.parent / "assets" / "latest"
+    nested_latest.parent.mkdir()
+    nested_latest.write_text("persistent payload\n", encoding="utf-8")
+    ordinary_latest = (
+        source / "Plugins" / "CACHE" / "market" / "ordinary" / "latest" / "SKILL.md"
+    )
+    ordinary_latest.parent.mkdir(parents=True)
+    ordinary_latest.write_text("ordinary version\n", encoding="utf-8")
+    plugin_state = source / "Plugins" / "data" / "bello.json"
+    plugin_state.parent.mkdir(parents=True)
+    plugin_state.write_text('{"enabled": true}\n', encoding="utf-8")
+    lock_file = source / "Thread-Writer-Locks" / "active.lock"
+    lock_file.parent.mkdir()
+    lock_file.write_text("locked\n", encoding="utf-8")
+    temp_lock = source / "TMP" / "arg0" / "active.lock"
+    temp_lock.parent.mkdir(parents=True)
+    temp_lock.write_text("locked\n", encoding="utf-8")
+    dot_temp_lock = source / ".TMP" / "plugins.sync.lock"
+    dot_temp_lock.parent.mkdir()
+    dot_temp_lock.write_text("locked\n", encoding="utf-8")
+
+    real_is_link = appserver_module.is_link_or_reparse
+    simulated_reparse_entries = {package_junction, plugin_cache_junction}
+    monkeypatch.setattr(appserver_module, "_IS_WINDOWS", True)
+    monkeypatch.setattr(
+        appserver_module,
+        "is_link_or_reparse",
+        lambda path, stat_result=None: (
+            path in simulated_reparse_entries
+            or real_is_link(path, stat_result=stat_result)
+        ),
+    )
+
+    isolated = _create_isolated_codex_home(source)
+    try:
+        assert (isolated / "auth.json").read_text(encoding="utf-8") == (
+            '{"token": "source"}\n'
+        )
+        assert (isolated / "Plugins" / "data" / "bello.json").is_file()
+        assert (
+            isolated
+            / "Plugins"
+            / "CACHE"
+            / "market"
+            / "bundle"
+            / "1.2.3"
+            / "SKILL.md"
+        ).is_file()
+        assert (
+            isolated
+            / "Plugins"
+            / "CACHE"
+            / "market"
+            / "bundle"
+            / "1.2.3"
+            / "assets"
+            / "latest"
+        ).is_file()
+        assert (
+            isolated
+            / "Plugins"
+            / "CACHE"
+            / "market"
+            / "ordinary"
+            / "latest"
+            / "SKILL.md"
+        ).is_file()
+        assert not (isolated / "Packages").exists()
+        assert not (
+            isolated / "Plugins" / "CACHE" / "market" / "bundle" / "latest"
+        ).exists()
+        assert not (isolated / "Thread-Writer-Locks").exists()
+        assert not (isolated / "TMP").exists()
+        assert not (isolated / ".TMP").exists()
+    finally:
+        appserver_module._remove_codex_home_tree(isolated)
+
+
+def test_isolated_codex_home_windows_still_rejects_non_cache_plugin_reparse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "codex-home"
+    plugin_state = source / "plugins" / "data"
+    plugin_state.mkdir(parents=True)
+    real_is_link = appserver_module.is_link_or_reparse
+
+    monkeypatch.setattr(appserver_module, "_IS_WINDOWS", True)
+    monkeypatch.setattr(
+        appserver_module,
+        "is_link_or_reparse",
+        lambda path, stat_result=None: (
+            path == plugin_state or real_is_link(path, stat_result=stat_result)
+        ),
+    )
+
+    with pytest.raises(AppServerError, match="reparse"):
+        _create_isolated_codex_home(source)
+
+
 def test_isolated_codex_home_windows_rejects_reparse_entries(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -195,6 +322,130 @@ def test_isolated_codex_home_windows_rejects_reparse_entries(
 
     with pytest.raises(AppServerError, match="reparse"):
         _create_isolated_codex_home(source)
+
+
+@pytest.mark.skipif(
+    os.name != "nt", reason="requires native Windows filesystem semantics"
+)
+def test_isolated_codex_home_handles_native_codex_junctions_and_locked_files(
+    tmp_path: Path,
+) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    source = tmp_path / "codex-home"
+    source.mkdir()
+    (source / "auth.json").write_text('{"token": "fixture"}\n', encoding="utf-8")
+    (source / "config.toml").write_text('model = "gpt-test"\n', encoding="utf-8")
+    plugin_state = source / "plugins" / "data" / "bello.json"
+    plugin_state.parent.mkdir(parents=True)
+    plugin_state.write_text('{"enabled": true}\n', encoding="utf-8")
+
+    plugin_version = (
+        source / "plugins" / "cache" / "openai-bundled" / "chrome" / "1.2.3"
+    )
+    plugin_version.mkdir(parents=True)
+    (plugin_version / "SKILL.md").write_text("plugin skill\n", encoding="utf-8")
+    package_version = source / "packages" / "standalone" / "1.2.3"
+    package_version.mkdir(parents=True)
+
+    junctions = (
+        (
+            source / "packages" / "standalone" / "current",
+            package_version,
+        ),
+        (
+            source / "plugins" / "cache" / "openai-bundled" / "chrome" / "latest",
+            plugin_version,
+        ),
+    )
+    for junction, target in junctions:
+        junction.parent.mkdir(parents=True)
+        result = subprocess.run(
+            [
+                "cmd.exe",
+                "/d",
+                "/s",
+                "/c",
+                "mklink",
+                "/J",
+                str(junction),
+                str(target),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode:
+            pytest.skip(
+                f"native junction creation unavailable: {result.stderr or result.stdout}"
+            )
+
+    lock_paths = (
+        source / "thread-writer-locks" / "active.lock",
+        source / "tmp" / "arg0" / "active.lock",
+        source / ".tmp" / "plugins.sync.lock",
+    )
+    for lock_path in lock_paths:
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text("locked\n", encoding="utf-8")
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handles: list[int] = []
+    try:
+        for lock_path in lock_paths:
+            handle = kernel32.CreateFileW(
+                str(lock_path),
+                0x80000000 | 0x40000000,
+                0,
+                None,
+                3,
+                0x80,
+                None,
+            )
+            if handle == wintypes.HANDLE(-1).value:
+                raise ctypes.WinError(ctypes.get_last_error())
+            handles.append(handle)
+
+        isolated = _create_isolated_codex_home(source)
+        try:
+            assert (isolated / "auth.json").is_file()
+            assert (isolated / "config.toml").is_file()
+            assert (isolated / "plugins" / "data" / "bello.json").is_file()
+            assert (
+                isolated
+                / "plugins"
+                / "cache"
+                / "openai-bundled"
+                / "chrome"
+                / "1.2.3"
+                / "SKILL.md"
+            ).is_file()
+            assert not (isolated / "packages").exists()
+            assert not (
+                isolated / "plugins" / "cache" / "openai-bundled" / "chrome" / "latest"
+            ).exists()
+            assert not (isolated / "thread-writer-locks").exists()
+            assert not (isolated / "tmp").exists()
+            assert not (isolated / ".tmp").exists()
+        finally:
+            appserver_module._remove_codex_home_tree(isolated)
+    finally:
+        for handle in handles:
+            kernel32.CloseHandle(handle)
 
 
 def test_configured_windows_codex_home_root_link_is_rejected_before_resolution(

--- a/tests/test_appserver.py
+++ b/tests/test_appserver.py
@@ -360,7 +360,7 @@ def test_isolated_codex_home_handles_native_codex_junctions_and_locked_files(
         ),
     )
     for junction, target in junctions:
-        junction.parent.mkdir(parents=True)
+        junction.parent.mkdir(parents=True, exist_ok=True)
         result = subprocess.run(
             [
                 "cmd.exe",


### PR DESCRIPTION
Related: #22.

Avoids copying reconstructible Codex runtime state on native Windows while preserving authentication, configuration, persistent plugin data, and versioned plugin payloads. Only actual plugin latest reparse aliases are omitted; unknown reparse entries remain fail-closed.

Adds regression coverage for Codex-managed junctions and files held with exclusive Windows sharing, including native Windows Server CI coverage.