### PR TITLE
Release Bello 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Bello"
-version = "0.5.0"
+version = "0.5.1"
 description = "Terminal supervisor for autonomous Codex app-server runs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/supervisor/appserver.py
+++ b/supervisor/appserver.py
@@ -565,7 +565,7 @@ class AppServerClient:
         result = await self.request(
             "initialize",
             {
-                "clientInfo": {"name": "bello", "title": "Bello", "version": "0.5.0"},
+                "clientInfo": {"name": "bello", "title": "Bello", "version": "0.5.1"},
                 "capabilities": {"experimentalApi": True, "requestAttestation": False},
             },
             timeout=timeout,


### PR DESCRIPTION
Prepare the Bello 0.5.1 patch release containing the native Windows CODEX_HOME isolation fix merged in #23.

- bump the package version to 0.5.1
- report 0.5.1 to Codex app-server

Verified locally: 922 passed, 7 skipped; wheel and sdist build successfully; twine metadata checks pass; clean wheel installation reports 0.5.1.