### PR TITLE
Release Bello 0.5.2: Astra model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,10 +452,68 @@ Open the interactive editor from your project folder:
 bello config
 ```
 
+To use a source checkout instead of a separately installed `bello`, activate
+the checkout's virtual environment with its dependencies installed, then run
+from the checkout directory:
+
+```bash
+python -m supervisor.main config
+```
+
+This edits the configuration for the current directory. Updating a checkout
+does not automatically update a separate pipx installation.
+
 The editor saves `.supervisor/config.json` for the project and shows only the
 settings relevant to the active pipeline. Choose the model and reasoning level
 for each role, enable completion review or adversarial testing, set review
 budgets, and optionally configure a revision coder, subagents, or the Fast tier.
+
+### Models and reasoning effort
+
+Each role can select **GPT-6 Astra** (`gpt-6-astra`), **GPT-5.6** with a
+Sol, Terra, or Luna variant, or **GPT-5.5**. Astra appears when the Codex
+model list or local model cache reports it, or when it is already saved in
+the project configuration. GPT-5.6 Sol at `xhigh` remains the default.
+
+These are Bello's built-in, model-specific effort choices. Model discovery
+controls which model names appear; it does not dynamically replace this table.
+
+| Model | Reasoning effort |
+| --- | --- |
+| GPT-6 Astra | `low`, `medium`, `high`, `xhigh`, `max`, `ultra` |
+| GPT-5.6 Sol / Terra | `low`, `medium`, `high`, `xhigh`, `max`, `ultra` |
+| GPT-5.6 Luna | `low`, `medium`, `high`, `xhigh`, `max` |
+| GPT-5.5 | `low`, `medium`, `high`, `xhigh` |
+
+Astra is a standalone selection, so it has no variant row. Switching to a
+model with fewer reasoning levels lowers an incompatible saved effort to
+that model's highest supported level. Astra's list above, including `ultra`,
+was verified against Codex CLI 0.153.4's app-server catalog and in live Bello
+runs. Codex reports supported levels through
+[`model/list` → `supportedReasoningEfforts`](https://learn.chatgpt.com/docs/app-server#list-models-modellist).
+
+### Why the desktop app may show fewer effort levels
+
+The desktop app's visible controls are not the full model capability list.
+The app can filter supported efforts through its own preferences, and its
+slider uses presets of model/effort combinations. Bello does not copy those
+desktop UI preferences. `Extra High` in the app is the same value as `xhigh`
+in Bello.
+
+In the inspected desktop build **26.901.41600**, `max` is not enabled in the
+visible-effort preferences by default, and showing `ultra` on the slider has
+a separate switch that defaults to off. When available, these controls are
+under **Settings → Configuration → Model features**:
+
+- **Available reasoning efforts** controls which supported levels appear.
+- **Ultra in model picker slider** controls whether the slider includes Ultra.
+
+The Model features section is itself gated by feature availability, so it may
+not appear in every installation. `agent` is the internal route name, not the
+visible menu label in that build. A missing option in the desktop UI alone
+does not establish that the Codex app-server rejects it.
+
+### Project settings
 
 CLI flags override matching values for one run without rewriting the saved
 configuration. The full setting list is below.
@@ -465,7 +523,7 @@ configuration. The full setting list is below.
 | `task` | absent | Default task file for this folder. When set, plain `bello` runs it, and `--task` always overrides. |
 | `coder-mod` | GPT-5.6 | Model family for the coder thread. |
 | `coder-5.6-variant` | Sol | GPT-5.6 variant for the coder: Sol, Terra, or Luna. |
-| `coder-intelligence` | `xhigh` | Coder reasoning effort, limited by the selected variant. |
+| `coder-intelligence` | `xhigh` | Coder reasoning effort, limited by the selected model. |
 | `revision-coder` | `off` | Start one fresh coder thread on the first returned completion-review or adversary finding. Later findings reuse that thread. |
 | `revision-coder-mod` / `revision-coder-5.6-variant` | GPT-5.6 Sol | Model for the revision thread. Hidden while `revision-coder` is off. |
 | `revision-coder-intelligence` | `xhigh` | Revision-coder reasoning effort. Hidden while `revision-coder` is off. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Bello"
-version = "0.5.1"
+version = "0.5.2"
 description = "Terminal supervisor for autonomous Codex app-server runs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/supervisor/appserver.py
+++ b/supervisor/appserver.py
@@ -565,7 +565,7 @@ class AppServerClient:
         result = await self.request(
             "initialize",
             {
-                "clientInfo": {"name": "bello", "title": "Bello", "version": "0.5.1"},
+                "clientInfo": {"name": "bello", "title": "Bello", "version": "0.5.2"},
                 "capabilities": {"experimentalApi": True, "requestAttestation": False},
             },
             timeout=timeout,

--- a/supervisor/config_editor.py
+++ b/supervisor/config_editor.py
@@ -23,6 +23,7 @@ from supervisor.project_config import (
     MODEL_GPT_5_6_LUNA,
     MODEL_GPT_5_6_SOL,
     MODEL_GPT_5_6_TERRA,
+    MODEL_GPT_6_ASTRA,
     SPEED_CHOICES,
     SUPPORTED_MODEL_CHOICES,
     ProjectConfig,
@@ -114,6 +115,7 @@ ULTRA_WAVE_FOREGROUNDS = (
 )
 ULTRA_EDGE_LEFT = "#9d58ed bg:#210b4c"
 ULTRA_EDGE_RIGHT = "#c06cff bg:#321067"
+MODEL_FAMILY_ASTRA_LABEL = "GPT-6 Astra"
 MODEL_FAMILY_5_6_LABEL = "GPT-5.6"
 MODEL_FAMILY_5_5_LABEL = "GPT-5.5"
 MODEL_VARIANT_LABELS = {
@@ -807,6 +809,8 @@ def _model_parameters(
     available = set(available_models)
     available_56 = [model for model in GPT_5_6_MODELS if model in available or model == selected_model]
     family_options: list[EditorOption] = []
+    if MODEL_GPT_6_ASTRA in available or selected_model == MODEL_GPT_6_ASTRA:
+        family_options.append(EditorOption(MODEL_FAMILY_ASTRA_LABEL, field, MODEL_GPT_6_ASTRA))
     if available_56:
         selected_56 = selected_model if selected_model in GPT_5_6_MODELS else available_56[0]
         family_options.append(EditorOption(MODEL_FAMILY_5_6_LABEL, field, selected_56))
@@ -840,6 +844,8 @@ def _model_parameters(
 
 
 def _model_family_label(model: str) -> str:
+    if model == MODEL_GPT_6_ASTRA:
+        return MODEL_FAMILY_ASTRA_LABEL
     if model in GPT_5_6_MODELS:
         return MODEL_FAMILY_5_6_LABEL
     if model == MODEL_GPT_5_5:

--- a/supervisor/project_config.py
+++ b/supervisor/project_config.py
@@ -14,6 +14,7 @@ from supervisor.review_limits import (
 )
 
 
+MODEL_GPT_6_ASTRA = "gpt-6-astra"
 MODEL_GPT_5_6_SOL = "gpt-5.6-sol"
 MODEL_GPT_5_6_TERRA = "gpt-5.6-terra"
 MODEL_GPT_5_6_LUNA = "gpt-5.6-luna"
@@ -23,7 +24,7 @@ GPT_5_6_MODELS = (
     MODEL_GPT_5_6_TERRA,
     MODEL_GPT_5_6_LUNA,
 )
-SUPPORTED_MODEL_CHOICES = (*GPT_5_6_MODELS, MODEL_GPT_5_5)
+SUPPORTED_MODEL_CHOICES = (MODEL_GPT_6_ASTRA, *GPT_5_6_MODELS, MODEL_GPT_5_5)
 DEFAULT_MODEL = MODEL_GPT_5_6_SOL
 DEFAULT_INTELLIGENCE = "xhigh"
 BASE_INTELLIGENCE_CHOICES = ("low", "medium", "high", "xhigh")
@@ -170,6 +171,9 @@ def default_project_config() -> ProjectConfig:
 
 
 def intelligence_choices_for_model(model: str) -> tuple[str, ...]:
+    if model == MODEL_GPT_6_ASTRA:
+        # Bello uses Codex app-server, whose Astra catalog includes ultra.
+        return INTELLIGENCE_CHOICES
     if model in {MODEL_GPT_5_6_SOL, MODEL_GPT_5_6_TERRA}:
         return INTELLIGENCE_CHOICES
     if model == MODEL_GPT_5_6_LUNA:

--- a/tests/test_astra_models.py
+++ b/tests/test_astra_models.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from supervisor.adversary_agent import AdversaryAgent
+from supervisor.coder import CoderSession
+from supervisor.config_editor import EditorState, available_model_choices, parameter_defs, render_editor, select_current
+from supervisor.main import _resolve_run_settings, cli
+from supervisor.project_config import (
+    DEFAULT_MODEL,
+    MODEL_GPT_5_5,
+    MODEL_GPT_5_6_LUNA,
+    MODEL_GPT_5_6_SOL,
+    MODEL_GPT_5_6_TERRA,
+    MODEL_GPT_6_ASTRA,
+    SUPPORTED_MODEL_CHOICES,
+    ProjectConfig,
+    intelligence_choices_for_model,
+    load_project_config,
+    project_config_path,
+    save_project_config,
+)
+from supervisor.state import StateStore
+from supervisor.supervisor_agent import StatelessSupervisorAgent
+
+
+ROLES = ("coder", "runtime", "completion", "adversary")
+ASTRA_EFFORTS = ("low", "medium", "high", "xhigh", "max", "ultra")
+
+
+def test_astra_catalog_preserves_existing_defaults_and_effort_limits() -> None:
+    assert SUPPORTED_MODEL_CHOICES == (
+        MODEL_GPT_6_ASTRA,
+        MODEL_GPT_5_6_SOL,
+        MODEL_GPT_5_6_TERRA,
+        MODEL_GPT_5_6_LUNA,
+        MODEL_GPT_5_5,
+    )
+    assert DEFAULT_MODEL == MODEL_GPT_5_6_SOL
+    assert intelligence_choices_for_model(MODEL_GPT_6_ASTRA) == ASTRA_EFFORTS
+    assert intelligence_choices_for_model(MODEL_GPT_5_6_SOL) == ASTRA_EFFORTS
+    assert intelligence_choices_for_model(MODEL_GPT_5_6_TERRA) == ASTRA_EFFORTS
+    assert intelligence_choices_for_model(MODEL_GPT_5_6_LUNA) == ASTRA_EFFORTS[:-1]
+    assert intelligence_choices_for_model(MODEL_GPT_5_5) == ASTRA_EFFORTS[:-2]
+
+
+@pytest.mark.parametrize("effort", ASTRA_EFFORTS)
+def test_astra_profiles_round_trip_project_and_runtime_config(tmp_path: Path, effort: str) -> None:
+    config = ProjectConfig(
+        completion_review=True,
+        adversary=True,
+        **{f"{role}_mod": MODEL_GPT_6_ASTRA for role in ROLES},
+        **{f"{role}_intelligence": effort for role in ROLES},
+    )
+    save_project_config(tmp_path, config)
+
+    reloaded = load_project_config(tmp_path, create=False)
+    settings = _resolve_run_settings(project_config=reloaded)
+    runtime_config = StateStore(tmp_path).get_bello_config()
+
+    assert reloaded == config
+    for role in ROLES:
+        assert getattr(settings, f"{role}_model") == MODEL_GPT_6_ASTRA
+        assert getattr(settings, f"{role}_intelligence") == effort
+        assert getattr(runtime_config, f"{role}_model") == MODEL_GPT_6_ASTRA
+        assert getattr(runtime_config, f"{role}_intelligence") == effort
+
+
+@pytest.mark.parametrize(
+    "efforts",
+    [("low", "medium", "high", "xhigh"), ("max", "ultra", "low", "medium")],
+)
+def test_astra_cli_overrides_are_independent_and_do_not_rewrite_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, efforts: tuple[str, ...]
+) -> None:
+    task = tmp_path / "TASK.md"
+    task.write_text("# Task\nPrint hello.\n", encoding="utf-8")
+    save_project_config(tmp_path, ProjectConfig(task="TASK.md"))
+    original_config = project_config_path(tmp_path).read_text(encoding="utf-8")
+    captured = []
+
+    async def fake_run_bello(settings):
+        captured.append(settings)
+        return 0
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("supervisor.main._startup_update_gate", lambda: None)
+    monkeypatch.setattr("supervisor.main._run_bello", fake_run_bello)
+    monkeypatch.setattr("supervisor.main._run_async_cleanly", asyncio.run)
+    arguments = ["--task", str(task)]
+    for role, effort in zip(ROLES, efforts):
+        arguments.extend([f"--{role}-mod", MODEL_GPT_6_ASTRA, f"--{role}-intelligence", effort])
+
+    result = CliRunner().invoke(cli, arguments)
+
+    assert result.exit_code == 0, result.output
+    assert len(captured) == 1
+    for role, effort in zip(ROLES, efforts):
+        assert getattr(captured[0], f"{role}_model") == MODEL_GPT_6_ASTRA
+        assert getattr(captured[0], f"{role}_intelligence") == effort
+    assert project_config_path(tmp_path).read_text(encoding="utf-8") == original_config
+
+
+def _select_option(config: ProjectConfig, key: str, label: str) -> ProjectConfig:
+    parameters = parameter_defs(config, model_choices=SUPPORTED_MODEL_CHOICES)
+    parameter_index = [parameter.key for parameter in parameters].index(key)
+    option_index = [option.label for option in parameters[parameter_index].options].index(label)
+    updated, _state, action = select_current(
+        config,
+        EditorState(parameter_index=parameter_index, expanded_index=parameter_index, option_index=option_index),
+        model_choices=SUPPORTED_MODEL_CHOICES,
+    )
+    assert action is None
+    return updated
+
+
+@pytest.mark.parametrize("role", ROLES)
+@pytest.mark.parametrize(
+    ("destination", "expected_effort"),
+    [(MODEL_GPT_5_6_SOL, "ultra"), (MODEL_GPT_5_6_LUNA, "max"), (MODEL_GPT_5_5, "xhigh")],
+)
+def test_editor_switches_astra_per_role_and_restores_model_specific_efforts(
+    role: str, destination: str, expected_effort: str
+) -> None:
+    original = ProjectConfig(completion_review=True, adversary=True)
+    config = _select_option(original, f"{role}_mod", "GPT-6 Astra")
+    config = _select_option(config, f"{role}_intelligence", "ultra")
+
+    assert getattr(config, f"{role}_mod") == MODEL_GPT_6_ASTRA
+    assert getattr(config, f"{role}_intelligence") == "ultra"
+    parameters = {parameter.key: parameter for parameter in parameter_defs(config)}
+    assert parameters[f"{role}_mod"].value == "GPT-6 Astra"
+    assert f"{role}_mod_variant" not in parameters
+    assert tuple(option.label for option in parameters[f"{role}_intelligence"].options) == ASTRA_EFFORTS
+
+    family = "GPT-5.5" if destination == MODEL_GPT_5_5 else "GPT-5.6"
+    config = _select_option(config, f"{role}_mod", family)
+    if destination == MODEL_GPT_5_6_LUNA:
+        config = _select_option(config, f"{role}_mod_variant", "Luna")
+    assert getattr(config, f"{role}_mod") == destination
+    assert getattr(config, f"{role}_intelligence") == expected_effort
+    parameters = {parameter.key: parameter for parameter in parameter_defs(config)}
+    assert tuple(option.label for option in parameters[f"{role}_intelligence"].options) == intelligence_choices_for_model(destination)
+
+    config = _select_option(config, f"{role}_mod", "GPT-6 Astra")
+    assert getattr(config, f"{role}_intelligence") == expected_effort
+    parameters = {parameter.key: parameter for parameter in parameter_defs(config)}
+    assert f"{role}_mod_variant" not in parameters
+    assert tuple(option.label for option in parameters[f"{role}_intelligence"].options) == ASTRA_EFFORTS
+    assert replace(config, **{f"{role}_mod": DEFAULT_MODEL, f"{role}_intelligence": "xhigh"}) == original
+
+
+@pytest.mark.parametrize("source", ["appserver", "cache", "unavailable"])
+def test_astra_discovery_uses_live_models_before_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, source: str
+) -> None:
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cache = tmp_path / ".codex" / "models_cache.json"
+    cache.parent.mkdir()
+    cache.write_text(json.dumps({"models": [{"slug": MODEL_GPT_6_ASTRA, "visibility": "list"}]}), encoding="utf-8")
+    reported = {
+        "appserver": (MODEL_GPT_6_ASTRA,),
+        "cache": (),
+        "unavailable": (MODEL_GPT_5_6_SOL,),
+    }[source]
+    monkeypatch.setattr("supervisor.config_editor._available_models_from_app_server", lambda project_root: reported)
+
+    choices = available_model_choices(tmp_path)
+
+    assert (MODEL_GPT_6_ASTRA in choices) is (source != "unavailable")
+    options = next(parameter.options for parameter in parameter_defs(ProjectConfig(), choices) if parameter.key == "coder_mod")
+    assert ("GPT-6 Astra" in [option.label for option in options]) is (source != "unavailable")
+    selected = ProjectConfig(coder_mod=MODEL_GPT_6_ASTRA)
+    selected_options = next(parameter.options for parameter in parameter_defs(selected, choices) if parameter.key == "coder_mod")
+    assert "GPT-6 Astra" in [option.label for option in selected_options]
+
+
+def test_editor_renders_astra_family_and_six_efforts() -> None:
+    config = ProjectConfig(coder_mod=MODEL_GPT_6_ASTRA, coder_intelligence="ultra")
+    parameters = parameter_defs(config)
+    effort_index = [parameter.key for parameter in parameters].index("coder_intelligence")
+    output = render_editor(
+        config,
+        EditorState(parameter_index=effort_index, expanded_index=effort_index),
+        Path("/tmp/project/.supervisor/config.json"),
+        width=120,
+        height=24,
+    )
+
+    assert "GPT-6 Astra" in output
+    assert "coder-5.6-variant" not in output
+    for effort in ASTRA_EFFORTS:
+        assert effort in output
+
+
+@pytest.mark.parametrize("role", ROLES)
+@pytest.mark.parametrize("effort", ["low", "ultra"])
+async def test_astra_profiles_reach_agent_thread_and_turn_requests(
+    store: StateStore, role: str, effort: str
+) -> None:
+    class RecordingClient:
+        def __init__(self) -> None:
+            self.thread_params = []
+            self.turn_params = []
+
+        async def thread_start(self, params, *, timeout):
+            self.thread_params.append(params)
+            return {"thread": {"id": "astra-thread"}}
+
+        async def turn_start(self, params, *, timeout):
+            self.turn_params.append(params)
+            if role == "adversary":
+                response = "candidate_finding: false\nattacked: output\nfindings: none\noverall: held"
+            elif role == "completion":
+                response = json.dumps(
+                    {
+                        "decision": "accept",
+                        "reason": "correct",
+                        "message_to_coder": None,
+                        "persistent_decision": None,
+                        "progress_update": None,
+                        "clear_handoff": False,
+                        "display_message": None,
+                        "handoff": None,
+                        "wake_sequence": 1,
+                        "generation": 0,
+                    }
+                )
+            else:
+                response = json.dumps({"decision": "noop", "reason": "correct"})
+            return {"turn": {"id": "astra-turn", "status": "completed", "items": [{"type": "agentMessage", "text": response}]}}
+
+        async def thread_archive(self, thread_id, *, timeout):
+            return {}
+
+    client = RecordingClient()
+    task = store.workspace / "TASK.md"
+    supervisor = StatelessSupervisorAgent(client, store, task, model=MODEL_GPT_6_ASTRA, intelligence=effort)
+    packet = supervisor.build_packet(wake_sequence=1, current_summary="minimal task complete")
+    if role == "coder":
+        agent = CoderSession(client, store, store.workspace, task, model=MODEL_GPT_6_ASTRA, intelligence=effort)
+        assert await agent.start_initial_turn() == "astra-turn"
+    elif role == "runtime":
+        assert (await supervisor.decide(packet)).decision == "noop"
+    elif role == "completion":
+        assert (await supervisor.decide_completion(packet)).decision == "accept"
+        await supervisor.close_completion_review()
+    else:
+        agent = AdversaryAgent(client, store.workspace, model=MODEL_GPT_6_ASTRA, intelligence=effort)
+        assert (await agent.run(packet)).candidate_finding is False
+
+    assert len(client.thread_params) == 1
+    assert len(client.turn_params) == 1
+    assert client.thread_params[0]["model"] == MODEL_GPT_6_ASTRA
+    assert client.turn_params[0]["model"] == MODEL_GPT_6_ASTRA
+    assert client.turn_params[0]["effort"] == effort

--- a/tests/test_config_editor_render.py
+++ b/tests/test_config_editor_render.py
@@ -560,7 +560,7 @@ def test_config_editor_renders_role_specific_reviewer_subagent_labels() -> None:
             expanded_index=completion_allowed_index,
         ),
         width=160,
-        height=40,
+        height=48,
     )
     adversary_output = _render(
         config,
@@ -569,7 +569,7 @@ def test_config_editor_renders_role_specific_reviewer_subagent_labels() -> None:
             expanded_index=adversary_allowed_index,
         ),
         width=160,
-        height=40,
+        height=48,
     )
 
     assert "completion-multi-agent" in completion_output


### PR DESCRIPTION
## Summary

- Merge the requested Astra support commit `2640f4e84e32cd8b06adc735b3cc83e7eee05fd6` into main without squashing it.
- Prepare Bello 0.5.2 by updating package and app-server client version strings.
- Preserve existing defaults and model-specific effort limits.

## Validation

- Full local test suite: 955 passed, 7 skipped.
- Built wheel and source distribution; `twine check` passed for both.
- Original Astra change has 33 new regression scenarios and three successful live smoke runs covering all six Astra efforts across the four roles.

After CI and merge, publish GitHub release `v0.5.2`; the existing Publish workflow then publishes the package to PyPI.
